### PR TITLE
不要そうな記述の削除もしくはコメントアウト

### DIFF
--- a/fb_majocairisLCD.c
+++ b/fb_majocairisLCD.c
@@ -89,59 +89,6 @@ static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye)
 	write_reg(par, MIPI_DCS_WRITE_MEMORY_START);
 }
 
-#define MEM_Y   BIT(7) /* MY row address order */
-#define MEM_X   BIT(6) /* MX column address order */
-#define MEM_V   BIT(5) /* MV row / column exchange */
-#define MEM_L   BIT(4) /* ML vertical refresh order */
-#define MEM_H   BIT(2) /* MH horizontal refresh order */
-#define MEM_BGR (3) /* RGB-BGR Order */
-static int set_var(struct fbtft_par *par)
-{
-	switch (par->info->var.rotate) {
-	case 0:
-		write_reg(par, MIPI_DCS_SET_ADDRESS_MODE,
-			  MEM_X | (par->bgr << MEM_BGR));
-		break;
-	case 270:
-		write_reg(par, MIPI_DCS_SET_ADDRESS_MODE,
-			  MEM_V | MEM_L | (par->bgr << MEM_BGR));
-		break;
-	case 180:
-		write_reg(par, MIPI_DCS_SET_ADDRESS_MODE,
-			  MEM_Y | (par->bgr << MEM_BGR));
-		break;
-	case 90:
-		write_reg(par, MIPI_DCS_SET_ADDRESS_MODE,
-			  MEM_Y | MEM_X | MEM_V | (par->bgr << MEM_BGR));
-		break;
-	}
-
-	return 0;
-}
-
-/*
- * Gamma string format:
- *  Positive: Par1 Par2 [...] Par15
- *  Negative: Par1 Par2 [...] Par15
- */
-#define CURVE(num, idx)  curves[(num) * par->gamma.num_values + (idx)]
-static int set_gamma(struct fbtft_par *par, u32 *curves)
-{
-	int i;
-
-	for (i = 0; i < par->gamma.num_curves; i++)
-		write_reg(par, 0xE0 + i,
-			  CURVE(i, 0), CURVE(i, 1), CURVE(i, 2),
-			  CURVE(i, 3), CURVE(i, 4), CURVE(i, 5),
-			  CURVE(i, 6), CURVE(i, 7), CURVE(i, 8),
-			  CURVE(i, 9), CURVE(i, 10), CURVE(i, 11),
-			  CURVE(i, 12), CURVE(i, 13), CURVE(i, 14));
-
-	return 0;
-}
-
-#undef CURVE
-
 static struct fbtft_display display = {
 	//.buswidth = 9,
 	.regwidth = 8,
@@ -155,8 +102,6 @@ static struct fbtft_display display = {
 		.write = fbtft_write_gpio8_wr,
 		.init_display = init_display,
 		.set_addr_win = set_addr_win,
-		//.set_var = set_var,
-		//.set_gamma = set_gamma,
 	},
 };
 

--- a/majocairis.dts
+++ b/majocairis.dts
@@ -43,7 +43,7 @@ $ sudo reboot
 		       majocairis_pins: majocairis_pins {
 				// 使用するピンとout/inの定義
 				brcm,pins     = <21 22 23 24 5 6 13 19 26 12 16 20>;
-				brcm,function = <1 1  1 1 1 1  1  1  1  1  1  1>; /* 1:out 0:in */
+				brcm,function = <1   1  1  1 1 1  1  1  1  1  1  1>; /* 1:out 0:in */
 			};
 		};
 	};

--- a/majocairis.dts
+++ b/majocairis.dts
@@ -1,5 +1,4 @@
 /* Device Tree for MajocaIris */
-/* NOT WORKING YET */
 /* ベースにした: https://gist.github.com/hgroll/2731ae6d05350df663b123615f765bf5 */
 
 /* compile

--- a/majocairis.dts
+++ b/majocairis.dts
@@ -90,7 +90,7 @@ $ sudo reboot
 						<&gpio 12 0>,
 						<&gpio 16 0>,
 						<&gpio 20 0>;
-				gamma = "00 1C 21 02 11 07 3D 79 4B 07 0F 0C 1B 1F 0F\n00 1C 20 04 0F 04 33 45 42 04 0C 0A 22 29 0F";
+				// gamma = "00 1C 21 02 11 07 3D 79 4B 07 0F 0C 1B 1F 0F\n00 1C 20 04 0F 04 33 45 42 04 0C 0A 22 29 0F";
 
 				/* https://github.com/notro/fbtft/issues/300#issuecomment-127012295 より。
 				   -1は0x1000000になる。-1,0xc8,0xff...と書いていた部分は0x10000C8,0xFF...となる


### PR DESCRIPTION
いくつかのコミットに分けてありますが、不要そうなものをコメントアウトしたり削除しました。

* dtsファイルは細かな修正のみです。
* ドライバー:
    * 使用していないset_varとset_gammaを消して警告を解消しました
    * fbtft_write_gpio8_wr_majocaは、fbtft-io.cのfbtft_write_gpio8_wrと同じように見えたので、fbtft_write_gpio8_wrに切り替えて動くことを確認して、削除しました。

dtsの方もコメントアウトを削ってしまって良いかなと思っていますがいかがでしょう。